### PR TITLE
Fix checksum verification for 64-bit JRE8

### DIFF
--- a/jre8/master/tools/chocolateyInstall.ps1
+++ b/jre8/master/tools/chocolateyInstall.ps1
@@ -99,10 +99,7 @@ $arguments = @{}
       } 
       elseif ($exclude -ne "64") 
       {
-        # Here $url64 is used twice to obtain the correct message from Chocolatey
-        # that it installed the 64-bit version, otherwise it would display 32-bit,
-        # regardless of the actual bitness of the software.
-        Install-ChocolateyPackage $packageName $installerType $installArgs64 $url64 $url64 -checksum64 $checksum64 -checksumtype64 'sha256'
+        Install-ChocolateyPackage $packageName $installerType $installArgs64 -url64bit $url64 -checksum64 $checksum64 -checksumtype64 'sha256'
       } 
       else 
       {


### PR DESCRIPTION
Currently, installation of the 64-bit JRE8 fails if the "allowEmptyCheckSumsSecure" option is disabled in Chocolatey.

This is because by default, Install-ChocolateyPackage considers package URLs to be for a 32-bit version, so the "checksum64" parameter doesn't apply to the 64-bit download and checksum verification is being skipped.

Using the "url64bit" parameter (as [recommended for 64-bit-only software](https://chocolatey.org/docs/helpers-install-chocolatey-package#url64bit-string)) should probably also prevent Chocolatey from displaying something about 32-bit as mentioned in the deleted comment, although I wasn't able to reproduce that message.