### PR TITLE
(jre8) update to latest build (8u141) via AU

### DIFF
--- a/jre8/master/jre8.nuspec
+++ b/jre8/master/jre8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>jre8</id>
-    <version>8.0.121</version>
+    <version>8.0.141</version>
     <title>Java SE Runtime Environment</title>
     <authors>Oracle</authors>
     <owners>Oracle</owners>
@@ -14,14 +14,17 @@
 
 ### Note
 
-This package installs the Java version offered at https://www.java.com. It also sets `SPONSORS=0`  ([see docs](http://docs.oracle.com/javase/7/docs/webnotes/install/windows/jre-installer-options.html#running)).
+This package installs the Java version offered at https://www.java.com. It also sets `SPONSORS=0` and uninstalls previous versions of Java with REMOVEOUTOFDATEJRES=1 ([see docs](http://docs.oracle.com/javase/7/docs/webnotes/install/windows/jre-installer-options.html#running)).
 
 If you wish to only install the 32-bit version of Java use the /exclude parameter. The switch to exclude 32-bit is /exclude:32 and to exclude 64-bit /exclude:64 
 For example: choco install jre8 -PackageParameters "/exclude:64" -y
 This package no longer manually adds an environment variable. 
 
-This package can install 32-bit, 64-bit, or both versions. Find on [GitHub](https://github.com/proudcanadianeh/ChocoPackages/tree/master/jre8/master)</description>
+This package can install 32-bit, 64-bit, or both versions.</description>
     <releaseNotes />
     <tags>java runtime environment</tags>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
 </package>

--- a/jre8/master/tools/chocolateyInstall.ps1
+++ b/jre8/master/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿try {
+try {
 
 $arguments = @{}
 
@@ -38,22 +38,23 @@ $arguments = @{}
 
   $scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
   # Import function to test if JRE in the same version is already installed
-  Import-Module (Join-Path $scriptDir 'thisJreInstalled.ps1')
+  . (Join-Path $scriptDir 'thisJreInstalled.ps1')
+  . (Join-Path $scriptDir 'packageArgs.ps1')
   
-  $packageName = 'jre8'
+  $packageName = $packageArgs.packageName
   # Modify these values -----------------------------------------------------
   # Find download URLs at http://www.java.com/en/download/manual.jsp
-  $url = 'https://javadl.oracle.com/webapps/download/AutoDL?BundleId=220313_d54c1d3a095b4ff2b6607d096fa80163'
-  $checksum32 = '73bf9257e2f4ca73318d3c23181cbe1e93665bf13fda7b956252a70b975bcf8b'
-  $url64 = 'https://javadl.oracle.com/webapps/download/AutoDL?BundleId=220315_d54c1d3a095b4ff2b6607d096fa80163'
-  $checksum64 = '5083590a30bf069e947dce8968221af21b39836fe013b111de70d6107b577cd3'
-  $oldVersion = '8.0.1210.13'
-  $version = '8.0.1310.11'
+  $url = $packageArgs.url
+  $checksum32 = $packageArgs.checksum
+  $url64 = $packageArgs.url64bit
+  $checksum64 = $packageArgs.checksum64
+  $oldVersion = $packageArgs.oldVersion
+  $version = $packageArgs.version
   #--------------------------------------------------------------------------
   $homepath = $version -replace "(\d+\.\d+)\.(\d\d)(.*)",'jre1.$1_$2'
   $installerType = 'exe'
-  $installArgs = "/s REBOOT=0 SPONSORS=0 AUTO_UPDATE=0 $32dir"
-  $installArgs64 = "/s REBOOT=0 SPONSORS=0 AUTO_UPDATE=0 $64dir"
+  $installArgs = "/s REBOOT=0 SPONSORS=0 REMOVEOUTOFDATEJRES=1 $32dir"
+  $installArgs64 = "/s REBOOT=0 SPONSORS=0 REMOVEOUTOFDATEJRES=1 $64dir"
   $osBitness = Get-ProcessorBits
    
   Write-Output "Searching if new version exists..."

--- a/jre8/master/tools/chocolateyUninstall.ps1
+++ b/jre8/master/tools/chocolateyUninstall.ps1
@@ -1,11 +1,12 @@
-﻿Write-Debug ("Starting " + $MyInvocation.MyCommand.Definition)
+Write-Debug ("Starting " + $MyInvocation.MyCommand.Definition)
 
 $scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 # Import function to test if JRE in the same version is already installed
-Import-Module (Join-Path $scriptDir 'thisJreInstalled.ps1')
+#Import-Module (Join-Path $scriptDir 'thisJreInstalled.ps1')
+  . (Join-Path $scriptDir 'thisJreInstalled.ps1')
 
 [string]$packageName="Javaruntime"
-$version = '8.0.1310.11'
+$version = '8.0.1010.13'
 $thisJreInstalledHash = thisJreInstalled($version)
 
 <#

--- a/jre8/master/tools/chocolateyUninstall.ps1
+++ b/jre8/master/tools/chocolateyUninstall.ps1
@@ -4,9 +4,10 @@ $scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 # Import function to test if JRE in the same version is already installed
 #Import-Module (Join-Path $scriptDir 'thisJreInstalled.ps1')
   . (Join-Path $scriptDir 'thisJreInstalled.ps1')
+  . (Join-Path $scriptDir 'packageArgs.ps1')
 
 [string]$packageName="Javaruntime"
-$version = '8.0.1010.13'
+$version = $packageArgs.version
 $thisJreInstalledHash = thisJreInstalled($version)
 
 <#

--- a/jre8/master/tools/packageArgs.ps1
+++ b/jre8/master/tools/packageArgs.ps1
@@ -1,0 +1,17 @@
+# Due to a big in AU. This package requires that all package Arguments be in this hashtable
+
+$packageArgs = @{
+	oldVersion		= '8.0.1310.11'
+	version			= '8.0.1410.15'
+	packageName		= 'jre8'
+	fileType		= 'exe'
+	url				= 'http://javadl.oracle.com/webapps/download/AutoDL?BundleId=224927_336fa29ff2bb4ef291e347e091f7f4a7'
+	url64bit		= 'http://javadl.oracle.com/webapps/download/AutoDL?BundleId=224929_336fa29ff2bb4ef291e347e091f7f4a7'
+	silentArgs		= '/s REBOOT=0 SPONSORS=0 REMOVEOUTOFDATEJRES=1'
+	validExitCodes	= @(0)
+	softwareName  	= 'Java SE Runtime Environment'
+	checksum		= 'D4AF33F78232898678488FF3747172209720A47460F4156032644D66A2B716CC'
+	checksumType	= 'sha256'
+	checksum64		= '5DD58AA25FA52DD3F35029F5C77CA9D94DE6CBCE89AB906008E0E3DD887C3F32'
+	checksumType64	= 'sha256'
+}

--- a/jre8/master/tools/thisJreInstalled.ps1
+++ b/jre8/master/tools/thisJreInstalled.ps1
@@ -1,7 +1,10 @@
-﻿# This function checks if the same version of JRE is already installed on the computer.
+# This function checks if the same version of JRE is already installed on the computer.
 # It returns a hash map with a 'x86_32' and 'x86_64'. These values are not empty if the
 # same version and bitness of JRE is already installed.
-function thisJreInstalled($version) {
+function thisJreInstalled() {
+param(
+	[string]$version
+)
   $productSearch = Get-WmiObject -Class Win32_Product | Where-Object {$_.Name -match '^Java \d+ Update \d+'}
   
   # The regexes for the name of the JRE registry entries (32- and 64 bit versions)

--- a/jre8/master/update.ps1
+++ b/jre8/master/update.ps1
@@ -1,0 +1,44 @@
+import-module au
+$releases = 'https://www.java.com/en/download/manual.jsp'
+
+function global:au_BeforeUpdate {
+	Get-RemoteFiles -Purge -FileNameBase "$($Latest.PackageName)Installer"
+	$file = Get-Item ".\tools\*.exe" | select -First 1
+	$Latest.fileVersion = $file.VersionInfo.ProductVersion -replace '((\d+.\d+.\d+.\d+))*','$1'
+	Remove-Item ".\tools\*.exe" -Force # Removal of downloaded files
+}
+
+function global:au_SearchReplace {
+	@{
+		".\tools\packageArgs.ps1" = @{
+			"(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+			"(?i)(^\s*url64bit\s*=\s*)('.*')"	= "`$1'$($Latest.URL64)'"
+			"(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+			"(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+			"(^\s*oldVersion\s*=\s*)('.*')" = "`$1'$($Latest.oldVersion)'"
+			"(^\s*version\s*=\s*)('.*')" = "`$1'$($Latest.fileVersion)'"
+		}
+	}
+}
+
+function global:au_GetLatest {
+  
+	$regex = '(\d\sUpdate\s\d{1,3})'
+	$download_page = Invoke-WebRequest -UseBasicParsing $releases
+	$download_page | foreach { $_ -match $regex } | Select -First 1 -skip 1
+	$version = $Matches[0]
+	$version = $version -replace(' Update ','.0.')
+	$url32 = $download_page.Links | where{ ($_ -match "Offline" ) } | Select -First 1
+	$url64 = $download_page.Links | where{ ($_ -match "(64-bit)" ) } | Select -First 1
+	(Get-Item ".\tools\packageArgs.ps1" | Select-String "(?i)(^\s*version\s*=\s*)('.*')") -split "=|'" | foreach { $_ -match '(\d+.\d+.\d+.\d+)' }
+	$oldVersion = $Matches[0]
+	@{
+		fileType	= 'exe'
+		Version		= $version
+		URL32		= $url32.href
+		URL64		= $url64.href
+		oldVersion	= $oldVersion
+    }
+}
+
+update -ChecksumFor none


### PR DESCRIPTION
@proudcanadianeh @dbenz04 
This has been updated to the latest version of JRE 8 update 141. This will update to the latest version get checksum(s) and even post to chocolatey if you want it. The [AU](https://github.com/majkinetor/au) is available free and can be run via Appveyor or local machine. I mentioned this in Issue #6 

I hope this will make being the maintainer of this package more enjoyable. 